### PR TITLE
Port PS3 Eye support to main (Qt5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ For advanced users who want to create AppImages:
 ./scripts/appimage/build_appimage_phase4.sh --clean
 ```
 
+Build the AppImage on a machine that has the same **development** packages as a full source build (see your distro guide). The packaging scripts enable webcam support (`ENABLE_WEBCAM=ON`), so install **V4L** and **OpenCV development** packages (e.g. Debian/Ubuntu: `libv4l-dev`, `libopencv-dev`) on the **build host** if you want webcam face tracking and PS3 Eye facetrack (`libp3eft`) in the image. **End users** who only run the published AppImage do **not** need OpenCV installed system-wide; OpenCV should be bundled inside the AppImage when the release was built with it. PS3 Eye LED/blob mode (`libp3e`) does not require OpenCV at build time.
+
 **[Full advanced documentation](docs/technical/)** - CMake options, packaging, and development guides.
 
 ## 🤝 Contributing

--- a/docs/readme/arch-linux.md
+++ b/docs/readme/arch-linux.md
@@ -30,6 +30,9 @@ sudo pacman -S winetricks cabextract wget
 sudo pacman -S libv4l v4l-utils opencv
 ```
 
+### AppImage / packaging build (maintainers)
+Install the **Webcam Support (Level 3+)** packages on the build host so the AppImage includes `libwc`, PS3 Eye (`libp3e`), and OpenCV-linked facetrack drivers where applicable. End users running the released AppImage do not need system OpenCV if the image was bundled correctly.
+
 ### OSC Support (Level 4+)
 ```bash
 sudo pacman -S liblo

--- a/docs/readme/debian-ubuntu.md
+++ b/docs/readme/debian-ubuntu.md
@@ -26,6 +26,9 @@ sudo apt install nsis  # REQUIRED: For Wine bridge installer generation
 sudo apt install libv4l-dev v4l-utils libopencv-dev
 ```
 
+### AppImage / packaging build (maintainers)
+The AppImage `prepare` step configures with webcam enabled. On the machine that runs `./scripts/appimage/build_appimage_phase4.sh` (or the v2 pipeline), install at least the **Webcam Support (Level 3+)** packages above so `libwc`, **PS3 Eye** (`libp3e`), and (with OpenCV) **PS3 facetrack** (`libp3eft`) are built and bundled. People who only download the AppImage do not need `libopencv-dev` on their system.
+
 ### OSC Support (Level 4+)
 ```bash
 sudo apt install libv4l-dev v4l-utils libopencv-dev
@@ -122,7 +125,7 @@ ls /opt/lib/linuxtrack/wine_bridge/
 | GUI not displaying on Wayland | Force X11: `QT_QPA_PLATFORM=xcb ltr_gui` |
 | Permission denied on device | Add user to groups: `sudo usermod -a -G plugdev,input $USER` |
 | `qmake: command not found` | Install Qt5 tools: `sudo apt install qttools5-dev-tools` |
-| OpenCV detection failed | Build succeeds but no webcam support. Install: `sudo apt install libopencv-dev` |
+| OpenCV detection failed | Facetrack / `libp3eft` missing; webcam without face mode may still work. On the **build** machine: `sudo apt install libopencv-dev`. AppImage users should get OpenCV from the bundle, not the distro. |
 
 ### Qt5 Tools PATH (Rare)
 If Qt5 tools aren't found, they should be in `/usr/lib/x86_64-linux-gnu/qt5/bin/`. Add to PATH if needed:

--- a/docs/readme/fedora-rhel.md
+++ b/docs/readme/fedora-rhel.md
@@ -31,6 +31,9 @@ sudo dnf install cabextract wget  # REQUIRED: For alternative installation metho
 sudo dnf install libv4l-devel v4l-utils opencv-devel
 ```
 
+### AppImage / packaging build (maintainers)
+Install the **Webcam Support (Level 3+)** packages on the machine that builds the AppImage so webcam, PS3 Eye (`libp3e`), and OpenCV-based facetrack plugins are included. Users who only run the AppImage are not required to install `opencv-devel` on their system.
+
 ### OSC Support (Level 4+)
 ```bash
 sudo dnf install liblo-devel

--- a/docs/readme/troubleshooting.md
+++ b/docs/readme/troubleshooting.md
@@ -49,7 +49,7 @@ sudo usermod -a -G plugdev,input $USER
 | Missing 32-bit headers | `bits/libc-header-start.h: No such file or directory` | **REQUIRED for Wine support**: Install 32-bit dev headers for your distro |
 | Qt5 tools not found | `qmake: command not found` | Add Qt5 bin directory to PATH (see distro guide) |
 | Wine dev tools missing | `winegcc: command not found` | Install Wine development packages |
-| OpenCV detection failed | Build succeeds but no webcam | Install OpenCV dev packages (non-critical) |
+| OpenCV detection failed | Build succeeds without facetrack / `libp3eft` | **Build-time only**: install OpenCV dev packages on the **builder** (see distro guide). AppImage **end users** should not need system OpenCV if the release bundles `libopencv_*`. |
 | ldconfig permission denied | Warning during install | Use `-DENABLE_LDCONFIG=OFF` for packaging |
 
 ### Runtime Issues

--- a/scripts/appimage/v2/bundle.sh
+++ b/scripts/appimage/v2/bundle.sh
@@ -466,28 +466,30 @@ EOHLP
         done
     done
 
-    # libwc is dlopen'd (not linked from ltr_gui); linuxdeploy does not pull OpenCV deps — copy them from ldd
-    wc_so=""
-    for candidate in usr/lib/linuxtrack/libwc.so.0.0.0 usr/lib/linuxtrack/libwc.so.0 usr/lib/linuxtrack/libwc.so; do
-        if [[ -f "$candidate" ]]; then
-            wc_so="$candidate"
-            break
+    # libwc / libp3eft are dlopen'd (not linked from ltr_gui); linuxdeploy does not pull OpenCV deps — copy from ldd
+    for plugin_base in libwc libp3eft; do
+        plug_so=""
+        for candidate in usr/lib/linuxtrack/${plugin_base}.so.0.0.0 usr/lib/linuxtrack/${plugin_base}.so.0 usr/lib/linuxtrack/${plugin_base}.so; do
+            if [[ -f "$candidate" ]]; then
+                plug_so="$candidate"
+                break
+            fi
+        done
+        if [[ -n "$plug_so" ]]; then
+            print_status "Bundling ${plugin_base} transitive deps (OpenCV / TBB / GOMP) for dlopen'd driver"
+            while IFS= read -r line; do
+                so_path=$(awk '/=>/{print $3}' <<<"$line" | tr -d ' ')
+                [[ -z "$so_path" || "$so_path" == "not" || ! -f "$so_path" ]] && continue
+                base=$(basename "$so_path")
+                case "$base" in
+                    libopencv*.so*|libtbb*.so*|libgomp*.so*)
+                        cp -n "$so_path" usr/lib/ 2>/dev/null || cp -f "$so_path" usr/lib/ 2>/dev/null || true
+                        print_status "Bundled ${plugin_base} dependency: $base"
+                        ;;
+                esac
+            done < <(ldd "$plug_so" 2>/dev/null || true)
         fi
     done
-    if [[ -n "$wc_so" ]]; then
-        print_status "Bundling libwc transitive deps (OpenCV / TBB / GOMP) for dlopen'd driver"
-        while IFS= read -r line; do
-            so_path=$(awk '/=>/{print $3}' <<<"$line" | tr -d ' ')
-            [[ -z "$so_path" || "$so_path" == "not" || ! -f "$so_path" ]] && continue
-            base=$(basename "$so_path")
-            case "$base" in
-                libopencv*.so*|libtbb*.so*|libgomp*.so*)
-                    cp -n "$so_path" usr/lib/ 2>/dev/null || cp -f "$so_path" usr/lib/ 2>/dev/null || true
-                    print_status "Bundled libwc dependency: $base"
-                    ;;
-            esac
-        done < <(ldd "$wc_so" 2>/dev/null || true)
-    fi
 
     # CRITICAL: Ensure all linuxtrack libraries use bundled dependencies
     print_status "Fixing library dependencies to use bundled versions"

--- a/scripts/appimage/v2/common.sh
+++ b/scripts/appimage/v2/common.sh
@@ -343,6 +343,7 @@ copy_udev_rules_if_present() {
     print_status "Copying udev rules if present"
     ensure_dir "$APPDIR/udev/rules.d"
     copy_if_exists "$PROJECT_ROOT/src/99-TIR.rules" "$APPDIR/udev/rules.d/"
+    copy_if_exists "$PROJECT_ROOT/src/99-PS3Eye.rules" "$APPDIR/udev/rules.d/"
     copy_if_exists "$PROJECT_ROOT/src/99-Mickey.rules" "$APPDIR/udev/rules.d/"
 }
 

--- a/scripts/appimage/v2/validate.sh
+++ b/scripts/appimage/v2/validate.sh
@@ -28,17 +28,33 @@ for lib in usr/lib/linuxtrack/libtir.so usr/lib/linuxtrack/libltusb1.so usr/lib/
     fi
 done
 
+# PS3 Eye plugin (USB 1415:2000)
+if [[ -f "$APPDIR/usr/lib/linuxtrack/libp3e.so.0" || -f "$APPDIR/usr/lib/linuxtrack/libp3e.so.0.0.0" ]]; then
+    print_success "Found PS3 Eye driver library (libp3e)"
+else
+    print_error "Missing PS3 Eye library: usr/lib/linuxtrack/libp3e.so.0 (or .so.0.0.0)"
+    failures=$((failures+1))
+fi
+
 # Webcam + face tracking (prepare.sh uses -DENABLE_WEBCAM=ON)
 if [[ -f "$APPDIR/usr/lib/linuxtrack/libwc.so.0" || -f "$APPDIR/usr/lib/linuxtrack/libwc.so.0.0.0" ]]; then
     print_status "Found webcam driver library (libwc)"
     opencv_bundled=$({ find "$APPDIR/usr/lib" -maxdepth 1 -name 'libopencv_*.so*' 2>/dev/null || true; } | wc -l)
     if [[ "$opencv_bundled" -gt 0 ]]; then
-        print_success "OpenCV runtime libraries present in AppDir for libwc"
+        print_success "OpenCV runtime libraries present in AppDir for libwc / facetrack drivers"
     else
-        print_warning "No libopencv_*.so in AppDir — face tracking may fail if libwc is not linked to OpenCV"
+        print_warning "No libopencv_*.so in AppDir — face tracking may fail if libwc or libp3eft link to OpenCV"
     fi
 else
     print_warning "libwc not in AppDir (webcam support may be disabled in this build)"
+fi
+
+if [[ -f "$APPDIR/usr/lib/linuxtrack/libp3eft.so.0" || -f "$APPDIR/usr/lib/linuxtrack/libp3eft.so.0.0.0" ]]; then
+    print_status "Found PS3 Eye facetrack library (libp3eft)"
+    opencv_for_p3=$({ find "$APPDIR/usr/lib" -maxdepth 1 -name 'libopencv_*.so*' 2>/dev/null || true; } | wc -l)
+    if [[ "$opencv_for_p3" -eq 0 ]]; then
+        print_warning "libp3eft present but no libopencv_*.so in AppDir — PS3 Eye face tracking may fail at runtime"
+    fi
 fi
 
 # Ensure 3D assets exist (GL 3D view)

--- a/src/99-PS3Eye.rules
+++ b/src/99-PS3Eye.rules
@@ -1,0 +1,2 @@
+# Sony PS3 Eye (USB 1415:2000) — libusb access without root
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1415", ATTRS{idProduct}=="2000", MODE="0666"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -255,6 +255,49 @@ if(WEBCAM_SUPPORT AND WITH_LIBV4L2)
     # endif()
 endif()
 
+# libp3e / libp3eft: PS3 Eye USB plugins (loaded by cal.c; not used on macOS build)
+if(NOT APPLE)
+    add_library(p3e SHARED
+        ps3eye_driver.c
+        runloop.c
+    )
+
+    set_target_properties(p3e PROPERTIES
+        VERSION 0.0.0
+        SOVERSION 0
+        OUTPUT_NAME "p3e"
+    )
+
+    target_link_libraries(p3e
+        ltr
+        ${MATH_LIBRARY}
+    )
+
+    if(FACE_TRACKER_SUPPORT)
+        add_library(p3eft SHARED
+            ps3eye_driver.c
+            runloop.c
+            facetrack.cpp
+        )
+
+        target_include_directories(p3eft PRIVATE ${OPENCV_INCLUDE_DIRS})
+        target_compile_options(p3eft PRIVATE ${OPENCV_CFLAGS_OTHER})
+        target_compile_definitions(p3eft PRIVATE OPENCV)
+
+        set_target_properties(p3eft PROPERTIES
+            VERSION 0.0.0
+            SOVERSION 0
+            OUTPUT_NAME "p3eft"
+        )
+
+        target_link_libraries(p3eft
+            ltr
+            ${MATH_LIBRARY}
+        )
+        target_link_libraries(p3eft PRIVATE ${OPENCV_LIBRARIES})
+    endif()
+endif()
+
 # ============================================================================
 # Helper Functions
 # ============================================================================
@@ -418,6 +461,19 @@ if(WEBCAM_SUPPORT)
     )
 endif()
 
+if(NOT APPLE)
+    install(TARGETS p3e
+        LIBRARY DESTINATION lib/linuxtrack
+        ARCHIVE DESTINATION lib/linuxtrack
+    )
+    if(FACE_TRACKER_SUPPORT)
+        install(TARGETS p3eft
+            LIBRARY DESTINATION lib/linuxtrack
+            ARCHIVE DESTINATION lib/linuxtrack
+        )
+    endif()
+endif()
+
 if(ENABLE_XPLANE AND XPLANE_SDK_FOUND)
     install(TARGETS xlinuxtrack9
         LIBRARY DESTINATION lib/linuxtrack
@@ -516,6 +572,7 @@ install(FILES
     linuxtrack_hello_world.c
     linuxtrack_hello_world_adv.c
     99-TIR.rules
+    99-PS3Eye.rules
     99-Mickey.rules
     haarcascade_frontalface_alt2.xml
     DESTINATION share/linuxtrack

--- a/src/qt_gui/device_setup.cpp
+++ b/src/qt_gui/device_setup.cpp
@@ -257,8 +257,8 @@ void DeviceSetup::refresh()
   res |= MacWebcamPrefs::AddAvailableDevices(*(ui.DeviceSelector));
 #else
   /* Optional libp3e/libp3eft: adds PS3 Eye entries when those plugins load and see a device. */
-  res |= MacP3ePrefs::AddAvailableDevices(*(ui.DeviceSelector));
-  res |= MacP3eFtPrefs::AddAvailableDevices(*(ui.DeviceSelector));
+  res |= MacP3ePrefs::AddAvailableDevices(*(ui.DeviceSelector), this);
+  res |= MacP3eFtPrefs::AddAvailableDevices(*(ui.DeviceSelector), this);
   res |= WebcamFtPrefs::AddAvailableDevices(*(ui.DeviceSelector));
   res |= WebcamPrefs::AddAvailableDevices(*(ui.DeviceSelector));
   res |= JoyPrefs::AddAvailableDevices(*(ui.DeviceSelector));

--- a/src/qt_gui/macps3eye_prefs.cpp
+++ b/src/qt_gui/macps3eye_prefs.cpp
@@ -4,6 +4,7 @@
 #include "ui_m_ps3eye_setup.h"
 #include "macps3eye_prefs.h"
 #include "ltr_gui_prefs.h"
+#include "trackir_permission_dialog.h"
 #include "ps3_prefs.h"
 #include "ps3eye_driver.h"
 #include "dyn_load.h"
@@ -229,7 +230,7 @@ void MacP3ePrefs::on_WebcamMaxBlobMac_valueChanged(int i)
   if(!initializing) ltr_int_wc_set_max_blob(i);
 }
 
-bool MacP3ePrefs::AddAvailableDevices(QComboBox &combo)
+bool MacP3ePrefs::AddAvailableDevices(QComboBox &combo, QWidget *dialogParent)
 {
   bool res = false;
   QString id;
@@ -239,7 +240,9 @@ bool MacP3ePrefs::AddAvailableDevices(QComboBox &combo)
     webcam_selected = true;
   }
   QVariant v;
-  if(find_p3e()){
+  const bool p3ok = find_p3e();
+  TrackIRPermissionDialog::offerIfPs3EyeNeedsUdev(dialogParent, p3ok);
+  if(p3ok){
     PrefsLink *pl = new PrefsLink(MACPS3EYE, QString::fromUtf8("PS3Eye"));
     v.setValue(*pl);
     combo.addItem(QString::fromUtf8("Ps3Eye"), v);

--- a/src/qt_gui/macps3eye_prefs.h
+++ b/src/qt_gui/macps3eye_prefs.h
@@ -12,7 +12,7 @@ class MacP3ePrefs : public QWidget{
  public:
   MacP3ePrefs(const QString &dev_id, QWidget *parent = 0);
   ~MacP3ePrefs();
-  static bool AddAvailableDevices(QComboBox &combo);
+  static bool AddAvailableDevices(QComboBox &combo, QWidget *dialogParent = nullptr);
  private:
   const QString id;
   bool Activate(const QString &ID, bool init = false);

--- a/src/qt_gui/macps3eyeft_prefs.cpp
+++ b/src/qt_gui/macps3eyeft_prefs.cpp
@@ -7,6 +7,7 @@
 #include <QFileDialog>
 #include "ui_m_ps3eye_ft_setup.h"
 #include "macps3eyeft_prefs.h"
+#include "trackir_permission_dialog.h"
 #include "ltr_gui_prefs.h"
 #include "ps3_prefs.h"
 #include "ps3eye_driver.h"
@@ -236,7 +237,7 @@ void MacP3eFtPrefs::on_WebcamResolutionsMac_activated(int index)
   ltr_int_ps3_set_ctrl_val(e_FPS, fps);
 }
 
-bool MacP3eFtPrefs::AddAvailableDevices(QComboBox &combo)
+bool MacP3eFtPrefs::AddAvailableDevices(QComboBox &combo, QWidget *dialogParent)
 {
   bool res = false;
   QString id;
@@ -246,7 +247,9 @@ bool MacP3eFtPrefs::AddAvailableDevices(QComboBox &combo)
     webcam_selected = true;
   }
   QVariant v;
-  if(find_p3e()){
+  const bool p3ok = find_p3e();
+  TrackIRPermissionDialog::offerIfPs3EyeNeedsUdev(dialogParent, p3ok);
+  if(p3ok){
     PrefsLink *pl = new PrefsLink(MACPS3EYE_FT, QString::fromUtf8("PS3Eye-face"));
     v.setValue(*pl);
     combo.addItem(QString::fromUtf8("Ps3Eye face tracker"), v);

--- a/src/qt_gui/macps3eyeft_prefs.h
+++ b/src/qt_gui/macps3eyeft_prefs.h
@@ -12,7 +12,7 @@ class MacP3eFtPrefs : public QWidget{
  public:
   MacP3eFtPrefs(const QString &dev_id, QWidget *parent = 0);
   ~MacP3eFtPrefs();
-  static bool AddAvailableDevices(QComboBox &combo);
+  static bool AddAvailableDevices(QComboBox &combo, QWidget *dialogParent = nullptr);
  private:
   const QString id;
   bool Activate(const QString &ID, bool init = false);

--- a/src/qt_gui/trackir_permission_dialog.cpp
+++ b/src/qt_gui/trackir_permission_dialog.cpp
@@ -1,6 +1,9 @@
 #include "trackir_permission_dialog.h"
 #include <QApplication>
 #include <QDir>
+#include <QFile>
+#include <QProcess>
+#include <QWidget>
 #include <QStandardPaths>
 #include <QTextStream>
 #include <QDebug>
@@ -32,7 +35,7 @@ TrackIRPermissionDialog::TrackIRPermissionDialog(QWidget *parent)
 {
     setupUI();
     setWindowIcon(QIcon(QStringLiteral(":/ltr/linuxtrack.svg")));
-    setWindowTitle(tr("TrackIR Permission Setup"));
+    setWindowTitle(tr("USB tracking device permissions"));
     setModal(true);
     setFixedSize(500, 300);
 }
@@ -47,13 +50,13 @@ void TrackIRPermissionDialog::setupUI()
     
     // Main message
     QLabel *messageLabel = new QLabel(tr(
-        "<h3>TrackIR Device Detected</h3>"
-        "<p>LinuxTrack has detected your TrackIR device, but you don't have "
-        "permissions to access it. This can be fixed by installing udev rules "
-        "and adding your user to the required groups.</p>"
+        "<h3>USB tracking device detected</h3>"
+        "<p>LinuxTrack detected a USB tracker (TrackIR/SmartNav and/or PlayStation Eye), but "
+        "your user may not have permission to access it. This can be fixed by installing udev "
+        "rules and adding your user to the required groups.</p>"
         "<p><b>What this will do:</b></p>"
         "<ul>"
-        "<li>Install udev rules to allow access to TrackIR devices</li>"
+        "<li>Install udev rules for TrackIR, PlayStation Eye (1415:2000), and Mickey/uinput</li>"
         "<li>Add your user to the required groups (plugdev, input, uinput)</li>"
         "<li>Reload udev rules to apply changes</li>"
         "</ul>"
@@ -146,19 +149,23 @@ void TrackIRPermissionDialog::onSkipClicked()
 
 void TrackIRPermissionDialog::onHelpClicked()
 {
-    QMessageBox::information(this, tr("TrackIR Permission Help"),
+    QMessageBox::information(this, tr("USB device permission help"),
         tr("<h3>Manual Setup Instructions</h3>"
            "<p>If the automatic setup doesn't work, you can configure permissions manually:</p>"
-           "<p><b>1. Install udev rules:</b></p>"
-           "<pre>sudo cp /path/to/linuxtrack/src/99-TIR.rules /etc/udev/rules.d/\n"
+           "<p><b>1. Install udev rules</b> (paths may be <code>/lib/udev/rules.d/</code> or <code>/etc/udev/rules.d/</code>):</p>"
+           "<pre>sudo cp /path/to/linuxtrack/src/99-TIR.rules /lib/udev/rules.d/\n"
+           "sudo cp /path/to/linuxtrack/src/99-PS3Eye.rules /lib/udev/rules.d/\n"
+           "sudo cp /path/to/linuxtrack/src/99-Mickey.rules /lib/udev/rules.d/\n"
            "sudo udevadm control --reload-rules</pre>"
            "<p><b>2. Add user to required groups:</b></p>"
            "<pre>sudo usermod -a -G plugdev,input,uinput $USER</pre>"
            "<p><b>3. Reboot your system</b></p>"
-           "<p><b>4. Test TrackIR access:</b></p>"
-           "<pre>lsusb | grep 131d</pre>"
-           "<p><b>Note:</b> You may need to create a 99-TIR.rules file with the content:</p>"
+           "<p><b>4. Test devices:</b></p>"
+           "<pre>lsusb | grep 131d   # TrackIR\n"
+           "lsusb | grep 1415     # PlayStation Eye</pre>"
+           "<p><b>Note:</b> TrackIR rule content (vendor 131d):</p>"
            "<pre>SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"131d\", MODE=\"0666\"</pre>"
+           "<p>PS3 Eye (1415:2000): see <code>99-PS3Eye.rules</code> in the source tree.</p>"
            "<p>For more detailed help, see the LinuxTrack documentation."));
 }
 
@@ -231,26 +238,24 @@ bool TrackIRPermissionDialog::installUdevRulesAndGroups()
 {
     // Show custom sudo dialog with manual instructions
     QString instructions = tr(
-        "TrackIR Setup Instructions:\n\n"
+        "USB tracking device setup:\n\n"
         "The automatic installation will:\n"
-        "• Install udev rules for TrackIR devices\n"
+        "• Install udev rules for TrackIR, PlayStation Eye (1415:2000), and Mickey/uinput\n"
         "• Add your user to required groups (plugdev, input, uinput)\n"
         "• Reload udev rules to apply changes\n\n"
         "If you prefer to do this manually, you can:\n\n"
-        "1. Install udev rules:\n"
-        "   sudo cp /path/to/linuxtrack/src/99-TIR.rules /etc/udev/rules.d/\n"
+        "1. Install udev rules under /etc/udev/rules.d/:\n"
+        "   sudo cp /path/to/linuxtrack/src/99-TIR.rules /path/to/linuxtrack/src/99-PS3Eye.rules /path/to/linuxtrack/src/99-Mickey.rules /etc/udev/rules.d/\n"
         "   sudo udevadm control --reload-rules\n\n"
         "2. Add user to groups:\n"
         "   sudo usermod -a -G plugdev,input,uinput $USER\n\n"
-        "3. <b>Reboot your system</b> for changes to take effect\n\n"
-        "4. Test TrackIR access:\n"
-        "   lsusb | grep 131d\n\n"
-        "Note: You may need to create a 99-TIR.rules file with the content:\n"
-        "   SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"131d\", MODE=\"0666\"\n\n"
+        "3. Reboot your system for changes to take effect\n\n"
+        "4. Test: lsusb | grep 131d   # TrackIR\n"
+        "   lsusb | grep 1415         # PlayStation Eye\n\n"
         "For more help, see the LinuxTrack documentation."
     );
 
-    SudoPasswordDialog dialog(tr("TrackIR Setup"), instructions, this);
+    SudoPasswordDialog dialog(tr("USB device setup"), instructions, this);
 
     if (dialog.exec() != QDialog::Accepted) {
         // User chose to cancel and do it manually
@@ -291,15 +296,20 @@ bool TrackIRPermissionDialog::installUdevRulesAndGroups()
         "KERNEL==\"uinput\", GROUP=\"uinput\", MODE=\"0660\"\n"
         "EOF\n"
         "\n"
-        "# Copy TrackIR rules to local admin location (/etc/udev/rules.d)\n"
-        "cp /tmp/99-TIR.rules %1/99-TIR.rules\n"
+        "# Create PlayStation Eye (PS3 Eye) udev rules\n"
+        "cat > /tmp/99-PS3Eye.rules << 'EOF'\n"
+        "SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"1415\", ATTRS{idProduct}==\"2000\", MODE=\"0666\"\n"
+        "EOF\n"
         "\n"
-        "# Copy Mickey rules to system location\n"
+        "# Copy udev rules to local admin location (/etc/udev/rules.d)\n"
+        "cp /tmp/99-TIR.rules %1/99-TIR.rules\n"
         "cp /tmp/99-Mickey.rules %1/99-Mickey.rules\n"
+        "cp /tmp/99-PS3Eye.rules %1/99-PS3Eye.rules\n"
         "\n"
         "# Set proper permissions\n"
         "chmod 644 %1/99-TIR.rules\n"
         "chmod 644 %1/99-Mickey.rules\n"
+        "chmod 644 %1/99-PS3Eye.rules\n"
         "\n"
         "# Create plugdev group if it doesn't exist (common on Arch Linux)\n"
         "if ! getent group plugdev > /dev/null 2>&1; then\n"
@@ -336,6 +346,7 @@ bool TrackIRPermissionDialog::installUdevRulesAndGroups()
         "# Clean up temp files\n"
         "rm -f /tmp/99-TIR.rules\n"
         "rm -f /tmp/99-Mickey.rules\n"
+        "rm -f /tmp/99-PS3Eye.rules\n"
         "\n"
         "echo \"Installation completed successfully\"\n"
     ).arg(udevRulesDir()).arg(currentUser);
@@ -457,8 +468,8 @@ void TrackIRPermissionDialog::showInstallationResult(bool success, const QString
 void TrackIRPermissionDialog::showLogoutDialog()
 {
     QMessageBox::StandardButton reply = QMessageBox::question(this, tr("Installation Complete"),
-        tr("<h3>TrackIR permissions have been successfully configured!</h3>"
-           "<p>The TrackIR and Mickey udev rules have been installed and your user has been added to the required groups.</p>"
+        tr("<h3>USB permissions have been successfully configured!</h3>"
+           "<p>The TrackIR, PlayStation Eye, and Mickey udev rules have been installed and your user has been added to the required groups.</p>"
            "<p><b>For these changes to take effect, you need to:</b></p>"
            "<p>1. <b>Reboot your system</b></p>"
            "<p>2. Unplug and replug your TrackIR device</p>"
@@ -487,6 +498,36 @@ void TrackIRPermissionDialog::setDialogShown()
     QSettings settings(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QString::fromUtf8("/linuxtrack/") + CONFIG_FILE, QSettings::IniFormat);
     settings.setValue(DONT_SHOW_KEY, true);
     settings.sync();
+}
+
+bool TrackIRPermissionDialog::isPs3EyeUdevRuleInstalled()
+{
+    return QFile::exists(QString::fromUtf8("/lib/udev/rules.d/99-PS3Eye.rules"))
+        || QFile::exists(QString::fromUtf8("/usr/lib/udev/rules.d/99-PS3Eye.rules"))
+        || QFile::exists(QString::fromUtf8("/etc/udev/rules.d/99-PS3Eye.rules"));
+}
+
+void TrackIRPermissionDialog::offerIfPs3EyeNeedsUdev(QWidget *parent, bool deviceAccessibleViaPlugin)
+{
+#if defined(Q_OS_LINUX)
+    if (!parent || deviceAccessibleViaPlugin || isPs3EyeUdevRuleInstalled() || !shouldShowDialog()) {
+        return;
+    }
+    QProcess lsusb;
+    lsusb.start(QStringLiteral("lsusb"), QStringList());
+    if (!lsusb.waitForFinished(8000) || lsusb.exitCode() != 0) {
+        return;
+    }
+    const QByteArray out = lsusb.readAllStandardOutput();
+    if (!out.contains("1415:2000")) {
+        return;
+    }
+    TrackIRPermissionDialog dialog(parent);
+    dialog.exec();
+#else
+    Q_UNUSED(parent);
+    Q_UNUSED(deviceAccessibleViaPlugin);
+#endif
 }
 
 // SudoPasswordDialog implementation

--- a/src/qt_gui/trackir_permission_dialog.h
+++ b/src/qt_gui/trackir_permission_dialog.h
@@ -14,6 +14,8 @@
 #include <QMessageBox>
 #include <QSettings>
 
+class QWidget;
+
 class TrackIRPermissionDialog : public QDialog
 {
     Q_OBJECT
@@ -24,6 +26,13 @@ public:
 
     static bool shouldShowDialog();
     static void setDialogShown();
+    /** True if PS3 Eye udev rule is present (common locations). */
+    static bool isPs3EyeUdevRuleInstalled();
+    /**
+     * Linux: if lsusb shows PS3 Eye (1415:2000), the udev rule is missing, the user has not
+     * suppressed the dialog, and the plugin cannot access the device, show the permission wizard.
+     */
+    static void offerIfPs3EyeNeedsUdev(QWidget *parent, bool deviceAccessibleViaPlugin);
 
 private slots:
     void onInstallRulesClicked();


### PR DESCRIPTION
Cherry-pick of `c5705fd` from `qt6-migration` (*Add PS3 Eye plugins (libp3e/libp3eft), udev rule, and GUI permission flow*). This is feature parity for the Qt5 line only, not a merge of the Qt6 branch.

Conflict resolution notes:
- `trackir_permission_dialog.cpp`: PS3 udev rules are installed alongside TrackIR/Mickey under `/etc/udev/rules.d` (same as pre-cherry-pick main), not hardcoded to `/lib/udev/rules.d`.
- `docs/readme/debian-ubuntu.md`: kept Qt5 `qttools5-dev-tools` for `qmake` and merged the PS3/OpenCV/AppImage wording from the cherry-pick.

Made with [Cursor](https://cursor.com)